### PR TITLE
added friendly urls, wip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ gem 'pg'
 gem 'inline_svg'
 gem 'haml', '~> 4.0.5'
 gem "haml-rails", "~> 0.9"
+gem 'friendly_id', '~> 5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     haml (4.0.7)
@@ -206,6 +208,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  friendly_id (~> 5.1.0)
   haml (~> 4.0.5)
   haml-rails (~> 0.9)
   inline_svg

--- a/app/assets/javascripts/lists.js.erb
+++ b/app/assets/javascripts/lists.js.erb
@@ -1,0 +1,16 @@
+$(function() {
+
+  // widow fix
+  $('.list li a').widowFix();
+  // keyboard shortcut for left/right arrows
+  $("body").keydown(function(e) {
+    if($('.prev-list-button').size() & e.keyCode == 37) { // left
+      $('.prev-list-button').addClass('active');
+      $('.prev-list-button')[0].click();
+    } else if($('.next-list-button').size() & e.keyCode == 39) { // right
+      $('.next-list-button').addClass('active');
+      $('.next-list-button')[0].click();
+    }
+  });
+
+});

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,0 @@
-class HomeController < ApplicationController
-  def index
-    # get the latest list
-    @list = List.last
-  end
-end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -6,6 +6,9 @@ class ListsController < ApplicationController
 
   def show
     @list = List.friendly.find(params[:id])
+    if request.path != list_path(@list)
+      redirect_to @list, status: :moved_permanently
+    end
   end
 
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,11 +1,11 @@
 class ListsController < ApplicationController
 
   def index
-    @lists = List.all
+    @list = List.last
   end
 
   def show
-    @list = List.find(params[:id])
+    @list = List.friendly.find(params[:id])
   end
 
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,6 +1,8 @@
 class Link < ApplicationRecord
   belongs_to :user
   belongs_to :list
+
+
   validate :on => :create do
     if list && list.links.length >= 5
       errors.add(:list, :too_many_links)

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,6 +1,9 @@
 class List < ApplicationRecord
   has_many :links
 
+  extend FriendlyId
+  friendly_id :publish_date
+
   def self.created_for_today
     list = List.last
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,8 +1,11 @@
 class List < ApplicationRecord
   has_many :links
-
   extend FriendlyId
-  friendly_id :publish_date
+  friendly_id :publish_date, use: [:slugged, :history]
+
+  # def should_generate_new_friendly_id?
+  #  new_record? || slug.blank?
+  # end
 
   def self.created_for_today
     list = List.last
@@ -13,6 +16,7 @@ class List < ApplicationRecord
 
     false
   end
+
 
   def previous_list
     self.class.where("publish_date < ?", publish_date).order(publish_date: :desc).first

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,2 +1,0 @@
-- if @list
-  = render '/partials/list'

--- a/app/views/lists/index.html.haml
+++ b/app/views/lists/index.html.haml
@@ -1,2 +1,2 @@
-- @lists.each do |list|
-  = link_to list.publish_date, list_path(list)
+- if @list
+  = render '/partials/list'

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root to: "lists#index"
+
   get 'admin/index'
   get 'admin/new_list'
   get 'admin/new_link'
@@ -16,5 +18,4 @@ Rails.application.routes.draw do
     put 'users' => 'devise/registrations#update', :as => 'user_registration'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   post 'admin/create_list'
   post 'admin/create_link'
 
-  resources :lists, only: [:index, :show]
+  resources :lists, only: [:index, :show], :path => '/'
 
   devise_for :users, :skip => [:registrations]
   as :user do

--- a/db/migrate/20170605203431_create_friendly_id_slugs.rb
+++ b/db/migrate/20170605203431_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20170614134701_add_slug_to_lists.rb
+++ b/db/migrate/20170614134701_add_slug_to_lists.rb
@@ -1,0 +1,6 @@
+class AddSlugToLists < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lists, :slug, :string
+    add_index :lists, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605203431) do
+ActiveRecord::Schema.define(version: 20170614134701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 20170605203431) do
     t.date     "publish_date"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.string   "slug"
+    t.index ["slug"], name: "index_lists_on_slug", using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517144823) do
+ActiveRecord::Schema.define(version: 20170605203431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
+  end
 
   create_table "links", force: :cascade do |t|
     t.string   "url"


### PR DESCRIPTION
Hey @nivshah here's what I did:
- added friendlyId gem(seems to be the way to go) 
    - https://github.com/norman/friendly_id/
    - after the `bundle install` you gotta do: `rails g friendly_id` & then `rake db:migrate`
- changed routing so `/lists/` is now `/`
- the above made the home controller/view unnecessary as long as we continue to only show a list. 
- we're now rooting to lists#index
- set the url slug to use the list's publish_date
  - _I still need to format the date, but it's workable for the moment_ 
 
and i'll stop pushing my gemfile.lock soon, i promise